### PR TITLE
Add support for nextpnr-gowin

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -82,6 +82,19 @@ jobs:
           yowasp-prjoxide --help
           yowasp-nextpnr-nexus --help
           yowasp-nextpnr-nexus --device LIFCL-40-9BG400CES --test
+      - name: Build Gowin binary wheels
+        run: |
+          ./package-pypi-gowin.sh
+      - name: Upload Gowin binary wheel artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheel
+          path: pypi-gowin/dist/
+      - name: Test Gowin binary wheels
+        run: |
+          pip install pypi-gowin/dist/*.whl
+          yowasp-nextpnr-gowin --help
+          yowasp-nextpnr-gowin --device GW1N-LV1QN48C6/I5 --test
   upload_wheels:
     needs: build
     runs-on: ubuntu-latest

--- a/build.sh
+++ b/build.sh
@@ -87,7 +87,7 @@ cargo install --target-dir prjoxide-build \
 cmake -B nextpnr-bba-build -S nextpnr-src/bba
 cmake --build nextpnr-bba-build
 
-python -m venv apycula-prefix
+${PYTHON:-python} -m venv apycula-prefix
 ./apycula-prefix/bin/pip install apycula
 
 mkdir -p nextpnr-build

--- a/build.sh
+++ b/build.sh
@@ -74,7 +74,8 @@ cmake -B prjtrellis-build -S prjtrellis-src/libtrellis \
 cmake --build prjtrellis-build
 
 cmake -B libtrellis-build -S prjtrellis-src/libtrellis \
-  -DCMAKE_INSTALL_PREFIX=$(pwd)/libtrellis-prefix
+  -DCMAKE_INSTALL_PREFIX=$(pwd)/libtrellis-prefix \
+  -DPYTHON_EXECUTABLE=${PYTHON} 
 make -C libtrellis-build install
 
 cargo build --target-dir prjoxide-build \

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,8 @@
 
 export SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
 
+PYTHON=$(which ${PYTHON:-python})
+
 WASI_SDK=wasi-sdk-11.0
 WASI_SDK_URL=https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-11/wasi-sdk-11.0-linux.tar.gz
 if ! [ -d ${WASI_SDK} ]; then curl -L ${WASI_SDK_URL} | tar xzf -; fi
@@ -87,13 +89,14 @@ cargo install --target-dir prjoxide-build \
 cmake -B nextpnr-bba-build -S nextpnr-src/bba
 cmake --build nextpnr-bba-build
 
-${PYTHON:-python} -m venv apycula-prefix
+${PYTHON} -m venv apycula-prefix
 ./apycula-prefix/bin/pip install apycula
 
 mkdir -p nextpnr-build
 cmake -B nextpnr-build -S nextpnr-src \
   -DCMAKE_TOOLCHAIN_FILE=../Toolchain-WASI.cmake \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+  -DPYTHON_EXECUTABLE=${PYTHON} \
   -DSTATIC_BUILD=ON \
   -DBOOST_ROOT=$(pwd)/${BOOST} \
   -DEigen3_DIR=$(pwd)/eigen-prefix/share/eigen3/cmake \

--- a/build.sh
+++ b/build.sh
@@ -90,7 +90,7 @@ cmake -B nextpnr-bba-build -S nextpnr-src/bba
 cmake --build nextpnr-bba-build
 
 ${PYTHON} -m venv apycula-prefix
-./apycula-prefix/bin/pip install apycula
+./apycula-prefix/bin/pip install apycula setuptools_scm
 
 mkdir -p nextpnr-build
 cmake -B nextpnr-build -S nextpnr-src \

--- a/build.sh
+++ b/build.sh
@@ -87,6 +87,9 @@ cargo install --target-dir prjoxide-build \
 cmake -B nextpnr-bba-build -S nextpnr-src/bba
 cmake --build nextpnr-bba-build
 
+python -m venv apycula-prefix
+./apycula-prefix/bin/pip install apycula
+
 mkdir -p nextpnr-build
 cmake -B nextpnr-build -S nextpnr-src \
   -DCMAKE_TOOLCHAIN_FILE=../Toolchain-WASI.cmake \
@@ -99,8 +102,9 @@ cmake -B nextpnr-build -S nextpnr-src \
   -DBUILD_PYTHON=OFF \
   -DEXTERNAL_CHIPDB=ON \
   -DEXTERNAL_CHIPDB_ROOT=/share \
-  -DARCH="ice40;ecp5;nexus" \
+  -DARCH="ice40;ecp5;nexus;gowin" \
   -DICESTORM_INSTALL_PREFIX=$(pwd)/icestorm-prefix \
   -DTRELLIS_INSTALL_PREFIX=$(pwd)/libtrellis-prefix \
-  -DOXIDE_INSTALL_PREFIX=$(pwd)/prjoxide-prefix
+  -DOXIDE_INSTALL_PREFIX=$(pwd)/prjoxide-prefix \
+  -DGOWIN_BBA_EXECUTABLE=$(pwd)/apycula-prefix/bin/gowin_bba
 cmake --build nextpnr-build

--- a/package-pypi-gowin.sh
+++ b/package-pypi-gowin.sh
@@ -1,0 +1,14 @@
+#!/bin/sh -ex
+
+PYTHON=${PYTHON:-python}
+
+mkdir -p pypi-gowin/yowasp_nextpnr_gowin/bin/
+cp nextpnr-build/nextpnr-gowin.wasm \
+   pypi-gowin/yowasp_nextpnr_gowin/
+mkdir -p pypi-gowin/yowasp_nextpnr_gowin/share/gowin
+cp nextpnr-build/gowin/chipdb/*.bin \
+   pypi-gowin/yowasp_nextpnr_gowin/share/gowin
+
+cd pypi-gowin
+rm -rf build && ${PYTHON} setup.py bdist_wheel
+sha256sum dist/*.whl

--- a/package-pypi-gowin.sh
+++ b/package-pypi-gowin.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -ex
 
-PYTHON=${PYTHON:-python}
+# Use venv python to extract Apcula version
+PYTHON=${PYTHON:-apycula-prefix/bin/python}
 
 mkdir -p pypi-gowin/yowasp_nextpnr_gowin/bin/
 cp nextpnr-build/nextpnr-gowin.wasm \

--- a/package-pypi-gowin.sh
+++ b/package-pypi-gowin.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 
 # Use venv python to extract Apycula version
-PYTHON=${PYTHON:-apycula-prefix/bin/python}
+PYTHON=apycula-prefix/bin/python
 
 mkdir -p pypi-gowin/yowasp_nextpnr_gowin/bin/
 cp nextpnr-build/nextpnr-gowin.wasm \

--- a/package-pypi-gowin.sh
+++ b/package-pypi-gowin.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 
 # Use venv python to extract Apycula version
-PYTHON=apycula-prefix/bin/python
+PYTHON=${PWD}/apycula-prefix/bin/python
 
 mkdir -p pypi-gowin/yowasp_nextpnr_gowin/bin/
 cp nextpnr-build/nextpnr-gowin.wasm \

--- a/package-pypi-gowin.sh
+++ b/package-pypi-gowin.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-# Use venv python to extract Apcula version
+# Use venv python to extract Apycula version
 PYTHON=${PYTHON:-apycula-prefix/bin/python}
 
 mkdir -p pypi-gowin/yowasp_nextpnr_gowin/bin/

--- a/pypi-gowin/.gitignore
+++ b/pypi-gowin/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+/*.egg-info
+/.eggs
+/build
+/dist
+
+/yowasp_*/share

--- a/pypi-gowin/setup.py
+++ b/pypi-gowin/setup.py
@@ -1,7 +1,15 @@
 import os
+import subprocess
+import sys
 from setuptools import setup, find_packages
 from setuptools_scm.git import parse as parse_git
 
+def apycula_version():
+    reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
+    for req in reqs.decode().splitlines():
+        if "Apycula" in req:
+            return req
+    raise Exception("Apycula not installed")
 
 def version():
     upstream_git = parse_git("../nextpnr-src")
@@ -30,7 +38,8 @@ setup_info = dict(
     install_requires=[
         "importlib_resources; python_version<'3.9'",
         "appdirs~=1.4",
-        "wasmtime>=0.28,<0.29"
+        "wasmtime>=0.28,<0.29",
+        apycula_version()
     ],
     packages=["yowasp_nextpnr_gowin"],
     package_data={

--- a/pypi-gowin/setup.py
+++ b/pypi-gowin/setup.py
@@ -3,15 +3,9 @@ import subprocess
 import sys
 from setuptools import setup, find_packages
 from setuptools_scm.git import parse as parse_git
+from importlib import metadata as importlib_metadata  # py3.8+ stdlib
 
 def apycula_version():
-    try:
-        try:
-            from importlib import metadata as importlib_metadata  # py3.8+ stdlib
-        except ImportError:
-            import importlib_metadata # py3.7- shim
-    except ImportError:
-        return "" # dummy version for 3.7
     return importlib_metadata.version('apycula')
 
 def version():
@@ -67,8 +61,7 @@ setup(
     long_description_content_type="text/markdown",
     license="ISC", # same as Yosys
     python_requires="~=3.5",
-    setup_requires=["setuptools_scm", "wheel",
-                    "importlib_metadata; python_version<'3.8'"],
+    setup_requires=["setuptools_scm", "wheel"],
     **setup_info,
     project_urls={
         "Homepage": "https://yowasp.github.io/",

--- a/pypi-gowin/setup.py
+++ b/pypi-gowin/setup.py
@@ -5,11 +5,14 @@ from setuptools import setup, find_packages
 from setuptools_scm.git import parse as parse_git
 
 def apycula_version():
-    reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
-    for req in reqs.decode().splitlines():
-        if "Apycula" in req:
-            return req
-    raise Exception("Apycula not installed")
+    try:
+        try:
+            from importlib import metadata as importlib_metadata  # py3.8+ stdlib
+        except ImportError:
+            import importlib_metadata # py3.7- shim
+    except ImportError:
+        return "" # dummy version for 3.7
+    return importlib_metadata.version('apycula')
 
 def version():
     upstream_git = parse_git("../nextpnr-src")
@@ -39,7 +42,7 @@ setup_info = dict(
         "importlib_resources; python_version<'3.9'",
         "appdirs~=1.4",
         "wasmtime>=0.28,<0.29",
-        apycula_version()
+        "Apycula=="+apycula_version()
     ],
     packages=["yowasp_nextpnr_gowin"],
     package_data={
@@ -64,7 +67,8 @@ setup(
     long_description_content_type="text/markdown",
     license="ISC", # same as Yosys
     python_requires="~=3.5",
-    setup_requires=["setuptools_scm", "wheel"],
+    setup_requires=["setuptools_scm", "wheel",
+                    "importlib_metadata; python_version<'3.8'"],
     **setup_info,
     project_urls={
         "Homepage": "https://yowasp.github.io/",

--- a/pypi-gowin/setup.py
+++ b/pypi-gowin/setup.py
@@ -1,0 +1,68 @@
+import os
+from setuptools import setup, find_packages
+from setuptools_scm.git import parse as parse_git
+
+
+def version():
+    upstream_git = parse_git("../nextpnr-src")
+    if upstream_git.exact:
+        nextpnr_version = upstream_git.format_with("{tag}")
+    else:
+        nextpnr_version = upstream_git.format_with("{tag}.post{distance}")
+
+    package_git = parse_git("..")
+    if not package_git.dirty:
+        package_version = package_git.format_with(".dev{distance}")
+    else:
+        package_version = package_git.format_with(".dev{distance}+dirty")
+
+    return nextpnr_version + package_version
+
+
+def long_description():
+    with open("../README.md") as f:
+        return f.read()
+
+
+setup_info = dict(
+    name="yowasp-nextpnr-gowin",
+    version=version(),
+    install_requires=[
+        "importlib_resources; python_version<'3.9'",
+        "appdirs~=1.4",
+        "wasmtime>=0.28,<0.29"
+    ],
+    packages=["yowasp_nextpnr_gowin"],
+    package_data={
+        "yowasp_nextpnr_gowin": [
+            "*.wasm",
+            "share/gowin/chipdb-*.bin",
+        ],
+    },
+    entry_points={
+        "console_scripts": [
+            "yowasp-nextpnr-gowin = yowasp_nextpnr_gowin:_run_nextpnr_gowin_argv",
+        ],
+    },
+)
+
+
+setup(
+    author="whitequark",
+    author_email="whitequark@whitequark.org",
+    description="nextpnr-gowin FPGA place and route tool",
+    long_description=long_description(),
+    long_description_content_type="text/markdown",
+    license="ISC", # same as Yosys
+    python_requires="~=3.5",
+    setup_requires=["setuptools_scm", "wheel"],
+    **setup_info,
+    project_urls={
+        "Homepage": "https://yowasp.github.io/",
+        "Source Code": "https://github.com/YoWASP/nextpnr",
+        "Bug Tracker": "https://github.com/YoWASP/nextpnr/issues",
+    },
+    classifiers=[
+        "License :: OSI Approved :: ISC License (ISCL)",
+    ],
+)

--- a/pypi-gowin/setup.py
+++ b/pypi-gowin/setup.py
@@ -3,10 +3,8 @@ import subprocess
 import sys
 from setuptools import setup, find_packages
 from setuptools_scm.git import parse as parse_git
-from importlib import metadata as importlib_metadata  # py3.8+ stdlib
+import importlib.metadata
 
-def apycula_version():
-    return importlib_metadata.version('apycula')
 
 def version():
     upstream_git = parse_git("../nextpnr-src")
@@ -36,7 +34,7 @@ setup_info = dict(
         "importlib_resources; python_version<'3.9'",
         "appdirs~=1.4",
         "wasmtime>=0.28,<0.29",
-        "Apycula=="+apycula_version()
+        "Apycula=={}".format(importlib.metadata.version("apycula"))
     ],
     packages=["yowasp_nextpnr_gowin"],
     package_data={

--- a/pypi-gowin/yowasp_nextpnr_gowin/__init__.py
+++ b/pypi-gowin/yowasp_nextpnr_gowin/__init__.py
@@ -59,9 +59,6 @@ def _run_wasm_app(wasm_filename, argv):
         return trap.code
 
 
-def run_prjoxide(argv):
-    return _run_wasm_app("prjoxide.wasm", ["yowasp-prjoxide", *argv])
-
 
 def run_nextpnr_gowin(argv):
     return _run_wasm_app("nextpnr-gowin.wasm", ["yowasp-nextpnr-gowin", *argv])

--- a/pypi-gowin/yowasp_nextpnr_gowin/__init__.py
+++ b/pypi-gowin/yowasp_nextpnr_gowin/__init__.py
@@ -59,7 +59,6 @@ def _run_wasm_app(wasm_filename, argv):
         return trap.code
 
 
-
 def run_nextpnr_gowin(argv):
     return _run_wasm_app("nextpnr-gowin.wasm", ["yowasp-nextpnr-gowin", *argv])
 

--- a/pypi-gowin/yowasp_nextpnr_gowin/__init__.py
+++ b/pypi-gowin/yowasp_nextpnr_gowin/__init__.py
@@ -1,0 +1,71 @@
+import os
+import sys
+import wasmtime
+import pathlib
+import hashlib
+import appdirs
+try:
+    from importlib import resources as importlib_resources
+    try:
+        importlib_resources.files # py3.9+ stdlib
+    except AttributeError:
+        import importlib_resources # py3.8- shim
+except ImportError:
+    import importlib_resources # py3.6- shim
+
+
+def _run_wasm_app(wasm_filename, argv):
+    module_binary = importlib_resources.read_binary(__package__, wasm_filename)
+    module_digest = hashlib.sha1(module_binary).digest()
+
+    wasi_cfg = wasmtime.WasiConfig()
+    wasi_cfg.argv = argv
+    wasi_cfg.preopen_dir(str(importlib_resources.files(__package__) / "share"), "/share")
+    wasi_cfg.preopen_dir("/", "/")
+    wasi_cfg.preopen_dir(".", ".")
+    wasi_cfg.inherit_stdin()
+    wasi_cfg.inherit_stdout()
+    wasi_cfg.inherit_stderr()
+
+    engine = wasmtime.Engine()
+    cache_path = pathlib.Path(os.getenv("YOWASP_CACHE_DIR", appdirs.user_cache_dir("yowasp")))
+    cache_path.mkdir(parents=True, exist_ok=True)
+    cache_filename = (cache_path / "{}-cache".format(wasm_filename))
+    digest_filename = (cache_path / "{}-digest".format(wasm_filename))
+    try:
+        with digest_filename.open("rb") as digest_file:
+            if digest_file.read() != module_digest:
+                raise Exception("cache miss")
+        with cache_filename.open("rb") as cache_file:
+            module = wasmtime.Module.deserialize(engine, cache_file.read())
+    except:
+        print("Preparing to run {}. This might take a while...".format(argv[0]), file=sys.stderr)
+        module = wasmtime.Module(engine, module_binary)
+        with cache_filename.open("wb") as cache_file:
+            cache_file.write(module.serialize())
+        with digest_filename.open("wb") as digest_file:
+            digest_file.write(module_digest)
+
+    linker = wasmtime.Linker(engine)
+    linker.define_wasi()
+    store = wasmtime.Store(engine)
+    store.set_wasi(wasi_cfg)
+    app = linker.instantiate(store, module)
+    linker.define_instance(store, "app", app)
+    try:
+        app.exports(store)["_start"](store)
+        return 0
+    except wasmtime.ExitTrap as trap:
+        return trap.code
+
+
+def run_prjoxide(argv):
+    return _run_wasm_app("prjoxide.wasm", ["yowasp-prjoxide", *argv])
+
+
+def run_nextpnr_gowin(argv):
+    return _run_wasm_app("nextpnr-gowin.wasm", ["yowasp-nextpnr-gowin", *argv])
+
+
+def _run_nextpnr_gowin_argv():
+    sys.exit(run_nextpnr_gowin(sys.argv[1:]))


### PR DESCRIPTION
Apycula seems to have a bit different build process than most other FOSS FPGA tools in that it's a Python package that bundles the chipdb, which is built in CI, so the only sensible way to install it is via pip. This means that bundling Apicula as a YoWasp package would be a huge PITA, but there would not be much benefit because it's already a Python package. So this PR only seeks to enable the nextpnr-gowin binary, which requires Apycula as a build dependency.

This PR is WIP, but just want to put it out there to see all the missing pieces and CI failures.
The first commit only adds gowin to the nextpnr build command, and does not yet bundle it into a PyPi package.